### PR TITLE
Adding table name to event output

### DIFF
--- a/lib/logstash/inputs/sqlite.rb
+++ b/lib/logstash/inputs/sqlite.rb
@@ -157,7 +157,7 @@ class LogStash::Inputs::Sqlite < LogStash::Inputs::Base
           rows = get_n_rows_from_table(@db, table_name, offset, @batch)
           count += rows.count
           rows.each do |row| 
-            event = LogStash::Event.new("host" => @host, "db" => @db)
+            event = LogStash::Event.new("host" => @host, "db" => @db, "table" => table_name)
             decorate(event)
             # store each column as a field in the event.
             row.each do |column, element|


### PR DESCRIPTION
In case there are several tables in the db it is useful to know where the data came from. 
