### PR TITLE
Update index.asciidoc

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -53,7 +53,7 @@ Then with this logstash config:
     }
     output {
       stdout {
-        debug => true
+        codec => rubydebug
       }
     }
 


### PR DESCRIPTION
`debug` is not a valid configuration option of the `stdout` plugin

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
